### PR TITLE
Use fullname, not name for PDB

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
-version: 0.6.1
+version: 0.6.2

--- a/stable/gcloud-sqlproxy/templates/pdb.yaml
+++ b/stable/gcloud-sqlproxy/templates/pdb.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    app: {{ template "gcloud-sqlproxy.name" . }}
+    app: {{ template "gcloud-sqlproxy.fullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -11,6 +11,6 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ template "gcloud-sqlproxy.name" . }}
+      app: {{ template "gcloud-sqlproxy.fullname" . }}
 {{ .Values.podDisruptionBudget | indent 2 }}
 {{- end -}}


### PR DESCRIPTION
https://github.com/helm/charts/tree/master/stable/gcloud-sqlproxy is marked deprecated so I'm sending the fix here.

The gcloud-sqlproxy deployment uses fullname but the PDB attempts to match by name. In my environment it meant the PDB didn't actually match anything.