### PR TITLE
Sqlproxy autogenerate service account

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
-version: 0.7.1
+version: 0.8.1

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -65,6 +65,8 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 | `serviceAccountKey`               | Service account key JSON file           | Must be provided and base64 encoded when no existing secret is used, in this case a new secret will be created holding this service account |
 | `existingSecret`                  | Name of an existing secret to be used for the cloud-sql credentials | `""`                                                            |
 | `existingSecretKey`               | The key to use in the provided existing secret   | `""`                                                                               |
+| `usingGCPController` | enable the use of the GCP Service Account Controller     | `false`                                                                                 |
+| `serviceAccountName` | specify a service account name to use     | `""`                                                                                                  |
 | `cloudsql.instances`              | List of PostgreSQL/MySQL instances      | [{instance: `instance`, project: `project`, region: `region`, port: 5432}] must be provided |
 | `resources`                       | CPU/Memory resource requests/limits     | Memory: `100/150Mi`, CPU: `100/150m`                                                        |
 | `nodeSelector`                    | Node Selector                           |                                                                                             |
@@ -80,6 +82,9 @@ $ helm install --name my-release -f values.yaml rimusz/gcloud-sqlproxy
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+### Auto generating the gcp service account
+By enabling the flag `usingGCPController` and having a GCP Service Account Controller deployed in your cluster, it is possible to autogenerate and inject the service account used for connecting to the database. For more information see https://github.com/kiwigrid/helm-charts/tree/master/charts/gcp-serviceaccount-controller
 
 ## Documentation
 

--- a/stable/gcloud-sqlproxy/templates/NOTES.txt
+++ b/stable/gcloud-sqlproxy/templates/NOTES.txt
@@ -1,6 +1,6 @@
 ** Please be patient while the chart is being deployed **
 
-{{ if not (or .Values.serviceAccountKey .Values.existingSecret) -}}
+{{ if not (include "gcloud-sqlproxy.hasCredentials" . ) -}}
 ################################################################################
 ####   WARNING: You did not provide Google Cloud Service Account key.       ####
 ################################################################################

--- a/stable/gcloud-sqlproxy/templates/_helpers.tpl
+++ b/stable/gcloud-sqlproxy/templates/_helpers.tpl
@@ -18,3 +18,31 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Generate gcp service account name
+*/}}
+{{- define "gcloud-sqlproxy.serviceAccountName" -}}
+{{ default (include "gcloud-sqlproxy.fullname" .) .Values.serviceAccountName }}
+{{- end -}}
+
+{{/*
+Generate key name in the secret
+*/}}
+{{- define "gcloud-sqlproxy.secretKey" -}}
+{{ default "credentials.json" .Values.existingSecretKey }}
+{{- end -}}
+
+{{/*
+Generate the secret name
+*/}}
+{{- define "gcloud-sqlproxy.secretName" -}}
+{{ default (include "gcloud-sqlproxy.fullname" .) .Values.existingSecret }}
+{{- end -}}
+
+{{/*
+Check if any type of credentials are defined
+*/}}
+{{- define "gcloud-sqlproxy.hasCredentials" -}}
+{{ or .Values.serviceAccountKey ( or .Values.existingSecret .Values.usingGCPController ) -}}
+{{- end -}}

--- a/stable/gcloud-sqlproxy/templates/deployment.yaml
+++ b/stable/gcloud-sqlproxy/templates/deployment.yaml
@@ -1,4 +1,5 @@
 {{- if ne (index .Values.cloudsql.instances 0).instance "instance" }}
+{{- $hasCredentials := include "gcloud-sqlproxy.hasCredentials" . -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -30,8 +31,8 @@ spec:
         - -instances={{- range .Values.cloudsql.instances -}}
                         {{ .project }}:{{ .region }}:{{ .instance }}=tcp:0.0.0.0:{{ .port }},
                      {{- end }}
-        {{ if or .Values.serviceAccountKey .Values.existingSecret -}}
-        - -credential_file=/secrets/cloudsql/{{- if .Values.existingSecret -}} {{ .Values.existingSecretKey }} {{- else -}} credentials.json {{- end }}
+        {{ if $hasCredentials -}}
+        - -credential_file=/secrets/cloudsql/{{ template "gcloud-sqlproxy.secretKey" . }}
         {{ end -}}
         {{- range $key, $value := .Values.extraArgs }}
         - --{{ $key }}={{ $value }}
@@ -42,17 +43,17 @@ spec:
           containerPort: {{ .port }}
         {{- end }}
         volumeMounts:
-        {{ if or .Values.serviceAccountKey .Values.existingSecret -}}
+        {{ if $hasCredentials -}}
         - name: cloudsql-oauth-credentials
           mountPath: /secrets/cloudsql
         {{ end -}}
         - name: cloudsql
           mountPath: /cloudsql
       volumes:
-      {{ if or .Values.serviceAccountKey .Values.existingSecret -}}
+      {{ if $hasCredentials -}}
       - name: cloudsql-oauth-credentials
         secret:
-          secretName: {{ default (include "gcloud-sqlproxy.fullname" .) .Values.existingSecret }}
+          secretName: {{ template "gcloud-sqlproxy.secretName" . }}
       {{ end -}}
       - name: cloudsql
         emptyDir: {}

--- a/stable/gcloud-sqlproxy/templates/gcpserviceaccount.yaml
+++ b/stable/gcloud-sqlproxy/templates/gcpserviceaccount.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.usingGCPController }}
+apiVersion: gcp.kiwigrid.com/v1beta1
+kind: GcpServiceAccount
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+    app.kubernetes.io/name: {{ include "gcloud-sqlproxy.fullname" . }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  name: {{ template "gcloud-sqlproxy.fullname" . }}
+spec:
+  serviceAccountIdentifier: {{ template "gcloud-sqlproxy.serviceAccountName" . }}
+  serviceAccountDescription: Service account for accessing a managed sql instance
+  secretName: {{ template "gcloud-sqlproxy.secretName" . }}
+  bindings:
+  {{ range .Values.cloudsql.instances -}}                     
+  - resource: "//cloudresourcemanager.googleapis.com/projects/{{ .project }}"
+    roles:
+    - roles/cloudsql.client
+  {{ end }}
+{{ end }}

--- a/stable/gcloud-sqlproxy/templates/secrets.yaml
+++ b/stable/gcloud-sqlproxy/templates/secrets.yaml
@@ -1,4 +1,5 @@
 {{- if not .Values.existingSecret -}}
+{{- if not .Values.usingGCPController -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,4 +13,5 @@ type: Opaque
 data:
   credentials.json: |-
     {{ .Values.serviceAccountKey }}
+{{- end -}}
 {{- end -}}

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -26,7 +26,7 @@ existingSecret: ""
 ## The key in the existing secret that stores the credenials
 existingSecretKey: ""
 
-## serviceAccountName to specify the service account name that will be generated 
+## serviceAccountName to specify the service account name that will be generated
 serviceAccountName: ""
 
 ## usingGCPController to control if the service account should be generated and injected

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -26,6 +26,12 @@ existingSecret: ""
 ## The key in the existing secret that stores the credenials
 existingSecretKey: ""
 
+## serviceAccountName to specify the service account name that will be generated 
+serviceAccountName: ""
+
+## usingGCPController to control if the service account should be generated and injected
+usingGCPController: false
+
 
 ## SQL connection settings
 ##


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for the gcp service account controller to the sql proxy (https://github.com/kiwigrid/gcp-serviceaccount-controller). The controller will create a service account that allows access to the sql instances and inject the key into the secret.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Changes are documented in the README.md
