### PR TITLE
Add network policy

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
-version: 0.8.1
+version: 0.9.0

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -71,6 +71,8 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 | `resources`                       | CPU/Memory resource requests/limits     | Memory: `100/150Mi`, CPU: `100/150m`                                                        |
 | `nodeSelector`                    | Node Selector                           |                                                                                             |
 | `rbac.create`                     | Create RBAC configuration w/ SA         | `false`                                                                                     |
+| `networkPolicy.enabled`           | Enable NetworkPolicy                    | `false` |
+| `networkPolicy.ingress.from`     | List of sources which should be able to access the pods selected for this rule. If empty, allows all sources. | `[]` |
 | `extraArgs`                       | Additional container arguments          | `{}`                                                                                        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -25,7 +25,7 @@ Install from remote URL with the release name `pg-sqlproxy` into namespace `sqlp
 
 ```console
 $ helm upgrade pg-sqlproxy rimusz/gcloud-sqlproxy --namespace sqlproxy \
-    --set serviceAccountKey="$(cat service-account.json | base64)" \
+    --set serviceAccountKey="$(cat service-account.json | base64 | tr -d '\n')" \
     --set cloudsql.instances[0].instance=INSTANCE \
     --set cloudsql.instances[0].project=PROJECT \
     --set cloudsql.instances[0].region=REGION \

--- a/stable/gcloud-sqlproxy/templates/networkpolicy.yaml
+++ b/stable/gcloud-sqlproxy/templates/networkpolicy.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: "{{ include "gcloud-sqlproxy.fullname" . }}"
+  labels:
+    app: {{ include "gcloud-sqlproxy.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ include "gcloud-sqlproxy.name" . }}
+      release: "{{ .Release.Name }}"
+  ingress:
+    # Allow inbound connections
+    - ports:
+      {{- range .Values.cloudsql.instances }}
+      - port: {{ .port }}
+      {{- end }}
+      from:
+{{ toYaml .Values.networkPolicy.ingress.from | indent 10 }}
+{{- end }}

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -58,6 +58,22 @@ cloudsql:
 rbac:
   create: false
 
+networkPolicy:
+  ## Specifies whether a NetworkPolicy should be created
+  ##
+  enabled: true
+
+  ingress:
+    from: []
+    # # List of sources which should be able to access the pods selected for this rule.
+    # # Items in this list are combined using a logical OR operation. 
+    # # If this field is empty or missing, this rule matches all sources (traffic not restricted by source). 
+    # # If this field is present and contains at least on item, 
+    # # this rule allows traffic only if the traffic matches at least one item in the from list.
+    #   - podSelector:           # chooses pods with gcloud-sqlproxy-client="true"
+    #       matchLabels:
+    #         gcloud-sqlproxy-client: "true"
+
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ## Resources are commente out as sometimes Memory/CPU limit causes spikes in query times

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -66,9 +66,9 @@ networkPolicy:
   ingress:
     from: []
     # # List of sources which should be able to access the pods selected for this rule.
-    # # Items in this list are combined using a logical OR operation. 
-    # # If this field is empty or missing, this rule matches all sources (traffic not restricted by source). 
-    # # If this field is present and contains at least on item, 
+    # # Items in this list are combined using a logical OR operation.
+    # # If this field is empty or missing, this rule matches all sources (traffic not restricted by source).
+    # # If this field is present and contains at least on item,
     # # this rule allows traffic only if the traffic matches at least one item in the from list.
     #   - podSelector:           # chooses pods with gcloud-sqlproxy-client="true"
     #       matchLabels:


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the option to create a network policy.

**Special notes for your reviewer**:
Hi @rimusz , I've essentially copy pasted the approach of network policies from charts in the stable helm repo.

There is a caveat though, when this norm was implemented, the following was not yet possible:
https://github.com/ahmetb/kubernetes-network-policy-recipes/blob/master/07-allow-traffic-from-some-pods-in-another-namespace.md

I would like to be able to allow some pods from various namespaces. Any suggestions as how to implement this? It would become the new norm, hopefully.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Changes are documented in the README.md
