### PR TITLE
Added option to deploy service as internal LB

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
-version: 0.11.0
+version: 0.12.0

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -70,6 +70,8 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 | `cloudsql.instances`              | List of PostgreSQL/MySQL instances      | [{instance: `instance`, project: `project`, region: `region`, port: 5432}] must be provided |
 | `resources`                       | CPU/Memory resource requests/limits     | Memory: `100/150Mi`, CPU: `100/150m`                                                        |
 | `nodeSelector`                    | Node Selector                           |                                                                                             |
+| `service.type`                    | Kubernetes LoadBalancer type            | `ClusterIP` |
+| `service.internalLB`              | Create service with `cloud.google.com/load-balancer-type: "Internal"` | Default `false`, when set to `true` you have to set also `service.type=LoadBalancer` |
 | `rbac.create`                     | Create RBAC configuration w/ SA         | `false`                                                                                     |
 | `networkPolicy.enabled`           | Enable NetworkPolicy                    | `false` |
 | `networkPolicy.ingress.from`     | List of sources which should be able to access the pods selected for this rule. If empty, allows all sources. | `[]` |

--- a/stable/gcloud-sqlproxy/templates/svc.yaml
+++ b/stable/gcloud-sqlproxy/templates/svc.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "gcloud-sqlproxy.fullname" . }}
-  {{- if .Values.service.internalLB  -}}
+  {{- if .Values.service.internalLB  }}
   annotations:
     cloud.google.com/load-balancer-type: "Internal"
-  {{- end -}}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "gcloud-sqlproxy.name" . }}
     helm.sh/chart: {{ include "gcloud-sqlproxy.chart" . }}

--- a/stable/gcloud-sqlproxy/templates/svc.yaml
+++ b/stable/gcloud-sqlproxy/templates/svc.yaml
@@ -2,12 +2,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "gcloud-sqlproxy.fullname" . }}
+  {{- if .Values.service.internalLB  -}}
+  annotations:
+    cloud.google.com/load-balancer-type: "Internal"
+  {{- end -}}
   labels:
     app.kubernetes.io/name: {{ include "gcloud-sqlproxy.name" . }}
     helm.sh/chart: {{ include "gcloud-sqlproxy.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
+  type: {{ .Values.service.type }}
   ports:
   {{- range .Values.cloudsql.instances }}
   - name: {{ .instance }}

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -58,6 +58,12 @@ cloudsql:
 rbac:
   create: false
 
+## Specifies service type and option to enable internal LoadBalancer
+## If service.internalLB is true, service.type shoul be: LoadBalancer
+service:
+  type: ClusterIP
+  internalLB: false
+
 networkPolicy:
   ## Specifies whether a NetworkPolicy should be created
   ##


### PR DESCRIPTION
<!--
Thank you for contributing to rimusz/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
GCP has a beta feature with allow to deploy service which is available internally in GCP network, is very useful when you need to access Kubernetes service outside cluster from GCP network:
https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing
I've added feature to enable that.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Changes are documented in the README.md
