### PR TITLE
Add documentation on how to pass CloudSQL Proxy extraArgs

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
-version: 0.14.0
+version: 0.14.1

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -1,3 +1,4 @@
+
 # GCP SQL Proxy
 
 [sql-proxy](https://cloud.google.com/sql/docs/postgres/sql-proxy) The Cloud SQL Proxy provides secure access to your Cloud SQL Postgres/MySQL instances without having to whitelist IP addresses or configure SSL.
@@ -83,6 +84,8 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 | `extraArgs`                       | Additional container arguments          | `{}`                                                                                        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+The `extraArgs` can be provided via dot notation, e.g. `--set extraArgs.log_debug_stdout=true` passes `--log_debug_stdout=false` to the SQL Proxy command.
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 


### PR DESCRIPTION
**What this PR does / why we need it**:

I tried to pass `extraArgs` to the Cloud SQL command via `helm --set` and it took me some time to figure out the syntax to specify the extraArgs map.

**Which issue this PR fixes**

This PR adds a tiny note to the Readme on how to specify `extraArgs` with `helm --set`. That's not that big of a deal and not really related to this chart in particular (basically that's the default way of specifying a map via `--set`). Nevertheless, I think it's helpful for users new to this chart  :)

If you think "this is something you should know when using helm charts and we should not document basic (or advanced) helm usage" than feel free to decline this PR :D

#### Checklist
- [X] Changes are documented in the README.md
