### PR TITLE
Add service.externalTrafficPolicy

### DIFF
--- a/stable/contour/Chart.yaml
+++ b/stable/contour/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: contour
 description: A Helm chart for Heptio Contour
-version: 0.3.0
+version: 0.3.1
 # Note that we use appVersion to get images tag, so make sure this is correct.
 appVersion: v0.12.0
 source: https://github.com/rimusz/charts/blob/master/stable/contour

--- a/stable/contour/README.md
+++ b/stable/contour/README.md
@@ -40,6 +40,7 @@ The following table lists the configurable parameters of the `Contour` chart and
 | `service.type`                       | Service type                                       | `LoadBalancer`                      |
 | `service.loadBalancerIP`             | Loadbalancer IP                                    | ``                                  |
 | `service.annotations`                | Service annotations                                | `{}`                                |
+| `service.externalTrafficPolicy`      | externalTrafficPolicy                              | `Cluster`                           |
 | `ingressRoutes.enabled`              | If true, Enable ingressRoutes CRD will be created  | `false`                             |
 | `resources`                          | Set Compute resources                              | `{}`                                |
 | `rbac.enabled`                       | Specifies whether RBAC resources should be created | `true`                              |

--- a/stable/contour/templates/service.yaml
+++ b/stable/contour/templates/service.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.service.type }}
+{{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: "{{ .Values.service.externalTrafficPolicy }}"
+{{- end }}
 {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"
 {{- end }}

--- a/stable/contour/values.yaml
+++ b/stable/contour/values.yaml
@@ -43,6 +43,12 @@ service:
   # for information about enabling the PROXY protocol on the ELB to recover
   # the original remote IP address.
   # service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+  # Due to the implementation of this feature, the source IP seen in the
+  # target container is not the original source IP of the client. To enable
+  # preservation of the client IP, the following fields can be configured in the
+  # service spec (supported in GCE/Google Kubernetes Engine environments)
+  # There are two available options: Cluster (default) and Local
+  # externalTrafficPolicy: "Cluster"
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
**What this PR does / why we need it**:
By setting .spec.externalTrafficPolicy to Local, the client IP addresses is propagated to the end Pods.

**Special notes for your reviewer**:
Hi @rimusz I want to add the ability to set service externalTrafficPolicy Local to the contour service

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Changes are documented in the README.md
