### PR TITLE
Use correct ClusterRole name in ClusterRoleBinding

### DIFF
--- a/stable/contour/templates/clusterrolebinding.yaml
+++ b/stable/contour/templates/clusterrolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "contour.name" . }}
+  name: {{ template "contour.fullname" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "contour.fullname" . }}


### PR DESCRIPTION
The ClusterRole binding currently uses the release name (countour.name) for ClusterRoleBinding.roleRef.name instead of the name of the ClusterRole that is actually created by the chart (contour.fullname). This will work only if the release name and the chart name are identical (so both are "contour"). This pull request corrects the roleRef name in the ClusterRoleBinding resource.