### PR TITLE
Bump gcloud-sqlproxy to 1.15

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -1,4 +1,4 @@
-appVersion: "1.14"
+appVersion: "1.15"
 description: Google Cloud SQL Proxy
 engine: gotpl
 home: https://cloud.google.com/sql/docs/postgres/sql-proxy
@@ -15,4 +15,4 @@ maintainers:
 name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
-version: 0.14.1
+version: 0.15.0

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -59,8 +59,8 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 
 | Parameter                         | Description                             | Default                                                                                     |
 | --------------------------------- | --------------------------------------  | ---------------------------------------------------------                                   |
-| `image`                           | SQLProxy image                          | `b.gcr.io/cloudsql-docker/gce-proxy`                                                        |
-| `imageTag`                        | SQLProxy image tag                      | `1.14`                                                                                      |
+| `image`                           | SQLProxy image                          | `gcr.io/cloudsql-docker/gce-proxy`                                                        |
+| `imageTag`                        | SQLProxy image tag                      | `1.15`                                                                                      |
 | `imagePullPolicy`                 | Image pull policy                       | `IfNotPresent`                                                                              |
 | `replicasCount`                   | Replicas count                          | `1`                                                                                         |
 | `serviceAccountKey`               | Service account key JSON file           | Must be provided and base64 encoded when no existing secret is used, in this case a new secret will be created holding this service account |

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -1,8 +1,8 @@
 ## Google Cloud SQL Proxy image
 ## ref: https://cloud.google.com/sql/docs/mysql/sql-proxy
 ## ref: https://cloud.google.com/sql/docs/postgres/sql-proxy
-image: b.gcr.io/cloudsql-docker/gce-proxy
-imageTag: "1.14"
+image: gcr.io/cloudsql-docker/gce-proxy
+imageTag: "1.15"
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
**What this PR does / why we need it**:

Update to the latest gcloud-sqlproxy. Also switches `b.gcr.io` which is now [deprecated](https://cloud.google.com/container-registry/docs/support/deprecation-notices) to `gcr.io`

**Which issue this PR fixes**

**Special notes for your reviewer**:

The image has a new [Dockerfile](https://github.com/GoogleCloudPlatform/cloudsql-proxy/pull/296). I don't expect any breaking changes, but probably worth looking into.

#### Checklist

- [x] Chart Version bumped
- [x] Changes are documented in the README.md
