### PR TITLE
Allow for custom local hostpath on the node

### DIFF
--- a/stable/hostpath-provisioner/templates/deployment.yaml
+++ b/stable/hostpath-provisioner/templates/deployment.yaml
@@ -31,6 +31,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: NODE_HOST_PATH
+              value: "{{ .Values.NodeHostPath }}"
           volumeMounts:
             - name: pv-volume
               mountPath: /mnt/hostpath
@@ -39,4 +41,4 @@ spec:
       volumes:
         - name: pv-volume
           hostPath:
-            path: /mnt/hostpath
+            path: {{ .Values.NodeHostPath }}

--- a/stable/hostpath-provisioner/values.yaml
+++ b/stable/hostpath-provisioner/values.yaml
@@ -21,6 +21,9 @@ storageClass:
   ## Set a StorageClass name
   name: hostpath
 
+## Set the local HostPath to be used on the node
+NodeHostPath: /mnt/hostpath
+
 rbac:
   create: true
   ## Ignored if rbac.create is true


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows the hostpath on the node to be set at deploy time

**Special notes for your reviewer**:
This is dependent on PR https://github.com/rimusz/hostpath-provisioner/pull/3
and the consequent docker image.

This PR will allow the setting of a custom node hostpath at deploy time. It defaults to the original "/mnt/hostpath"

Kind Regards