### PR TITLE
Bumping gcloud-sqlproxy version to 1.16

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -1,4 +1,4 @@
-appVersion: "1.15"
+appVersion: "1.16"
 description: Google Cloud SQL Proxy
 engine: gotpl
 home: https://cloud.google.com/sql/docs/postgres/sql-proxy
@@ -15,4 +15,4 @@ maintainers:
 name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
-version: 0.15.0
+version: 0.16.0

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -60,7 +60,7 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 | Parameter                         | Description                             | Default                                                                                     |
 | --------------------------------- | --------------------------------------  | ---------------------------------------------------------                                   |
 | `image`                           | SQLProxy image                          | `gcr.io/cloudsql-docker/gce-proxy`                                                        |
-| `imageTag`                        | SQLProxy image tag                      | `1.15`                                                                                      |
+| `imageTag`                        | SQLProxy image tag                      | `1.16`                                                                                      |
 | `imagePullPolicy`                 | Image pull policy                       | `IfNotPresent`                                                                              |
 | `replicasCount`                   | Replicas count                          | `1`                                                                                         |
 | `serviceAccountKey`               | Service account key JSON file           | Must be provided and base64 encoded when no existing secret is used, in this case a new secret will be created holding this service account |

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -2,7 +2,7 @@
 ## ref: https://cloud.google.com/sql/docs/mysql/sql-proxy
 ## ref: https://cloud.google.com/sql/docs/postgres/sql-proxy
 image: gcr.io/cloudsql-docker/gce-proxy
-imageTag: "1.15"
+imageTag: "1.16"
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
**What this PR does / why we need it**:

This updates the Cloud SQL proxy to the latest version available, 1.16.

**Special notes for your reviewer**:

The Docker image in 1.16 now uses a distroless base image, which means a shell is not available anymore (see https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/317). However, it does not look like a shell is being used anywhere in the current chart.

#### Checklist

- [x] Chart Version bumped
- [x] Changes are documented in the README.md
