### PR TITLE
Only create PDB for gcloud-sqlproxy if more than 1 replica

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
-version: 0.16.0
+version: 0.17.0

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -76,6 +76,7 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 | `autoscaling.targetCPUUtilizationPercentage` | Scaling target for CPU Utilization Percentage | `50`                                                                       |
 | `autoscaling.targetMemoryUtilizationPercentage` | Scaling target for Memory Utilization Percentage | `50`                                                                 |
 | `nodeSelector`                    | Node Selector                           |                                                                                             |
+| `podDisruptionBudget`             | Pod disruption budget                   | `maxUnavailable: 1` if `replicasCount` > 1, does not create the PDB otherwise               |
 | `service.type`                    | Kubernetes LoadBalancer type            | `ClusterIP`                                                                                 |
 | `service.internalLB`              | Create service with `cloud.google.com/load-balancer-type: "Internal"` | Default `false`, when set to `true` you have to set also `service.type=LoadBalancer` |
 | `rbac.create`                     | Create RBAC configuration w/ SA         | `false`                                                                                     |

--- a/stable/gcloud-sqlproxy/templates/pdb.yaml
+++ b/stable/gcloud-sqlproxy/templates/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.podDisruptionBudget -}}
+{{- if and .Values.podDisruptionBudget (gt (.Values.replicasCount | int) 1) -}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -111,6 +111,7 @@ tolerations: []
 ## Affinity
 affinity: {}
 
+## Configure the PodDisruptionBudget
 podDisruptionBudget: |
   maxUnavailable: 1
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This addresses the issue in https://github.com/rimusz/charts/issues/44 by implementing the recommended fix for the gcloud-sqlproxy chart. Now, the PodDisruptionBudget will not get created unless there is more than one replica.

**Which issue this PR fixes**: fixes #44

**Special notes for your reviewer**:

I have tested this with a replica count of 1 and 2 to verify that at 1, the PDB is not created, and at 2 it is created.

#### Checklist

- [x] Chart Version bumped
- [x] Changes are documented in the README.md
