### PR TITLE
Allowing setting of lifecycle hooks on gcloud-sqlproxy to improve reliability with autoscaling

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
-version: 0.16.0
+version: 0.17.0

--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
-version: 0.17.0
+version: 0.18.0

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -70,6 +70,7 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 | `serviceAccountName`              | specify a service account name to use   | `""`                                                                                        |
 | `cloudsql.instances`              | List of PostgreSQL/MySQL instances      | [{instance: `instance`, project: `project`, region: `region`, port: 5432}] must be provided |
 | `resources`                       | CPU/Memory resource requests/limits     | Memory: `100/150Mi`, CPU: `100/150m`                                                        |
+| `lifecycleHooks`                  | Container lifecycle hooks               | `{}`                                                                                        |
 | `autoscaling.enabled`             | Enable CPU/Memory horizontal pod autoscaler | `false`                                                                                 |
 | `autoscaling.minReplicas`         | Autoscaler minimum pod replica count    | `1`                                                                                         |
 | `autoscaling.maxReplicas`         | Autoscaler maximum pod replica count    | `3`                                                                                         |

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -76,6 +76,7 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 | `autoscaling.targetCPUUtilizationPercentage` | Scaling target for CPU Utilization Percentage | `50`                                                                       |
 | `autoscaling.targetMemoryUtilizationPercentage` | Scaling target for Memory Utilization Percentage | `50`                                                                 |
 | `nodeSelector`                    | Node Selector                           |                                                                                             |
+| `podDisruptionBudget`             | Pod disruption budget                   | `maxUnavailable: 1` if `replicasCount` > 1, does not create the PDB otherwise               |
 | `service.type`                    | Kubernetes LoadBalancer type            | `ClusterIP`                                                                                 |
 | `service.internalLB`              | Create service with `cloud.google.com/load-balancer-type: "Internal"` | Default `false`, when set to `true` you have to set also `service.type=LoadBalancer` |
 | `rbac.create`                     | Create RBAC configuration w/ SA         | `false`                                                                                     |

--- a/stable/gcloud-sqlproxy/templates/deployment.yaml
+++ b/stable/gcloud-sqlproxy/templates/deployment.yaml
@@ -38,6 +38,10 @@ spec:
         {{- range $key, $value := .Values.extraArgs }}
         - --{{ $key }}={{ $value }}
         {{- end }}
+        {{- if .Values.lifecycleHooks }}
+        lifecycle:
+{{ toYaml .Values.lifecycleHooks | indent 10 }}
+        {{- end }}
         ports:
         {{- range .Values.cloudsql.instances }}
         - name: {{ .instanceShortName | default (.instance | trunc 15) }}

--- a/stable/gcloud-sqlproxy/templates/pdb.yaml
+++ b/stable/gcloud-sqlproxy/templates/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.podDisruptionBudget -}}
+{{- if and .Values.podDisruptionBudget (gt (.Values.replicasCount | int) 1) -}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -111,6 +111,14 @@ tolerations: []
 ## Affinity
 affinity: {}
 
+## Lifecycle hooks
+## This can be helpful for gracefully terminating the proxy, when used in combination with the -term_timeout=10s extra arg
+## NOTE: Your Docker image must have a shell for the preStop command to work, the default Docker image does not have one
+lifecycleHooks: {}
+#   preStop:
+#     exec:
+#       command: ['sleep', '10']
+
 ## Configure the PodDisruptionBudget
 podDisruptionBudget: |
   maxUnavailable: 1

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -111,6 +111,7 @@ tolerations: []
 ## Affinity
 affinity: {}
 
+## Configure the PodDisruptionBudget
 podDisruptionBudget: |
   maxUnavailable: 1
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Traditionally, lifecycle hooks (particularly `preStop`) are used to gracefully stop the container. This is particularly important when used with autoscaling, as without this, I was getting connection errors when the autoscaler scaled down the proxy deployment, as connections were terminated before the queries were completed.

With this change, someone can add in their own lifecycle hooks to ensure that the pods terminate gracefully.

**Special notes for your reviewer**:

This presents an issue when combined with my other PR https://github.com/rimusz/charts/pull/60 as the latest SQL proxy version does not contain a shell that can be used with the preStop hooks. I've added a note in the README to indicate this.

#### Checklist

- [x] Chart Version bumped
- [x] Changes are documented in the README.md
