### PR TITLE
Allowing terminationGracePeriodSeconds to be set for gcloud-sqlproxy

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
-version: 0.18.0
+version: 0.19.0

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -76,6 +76,7 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 | `autoscaling.maxReplicas`         | Autoscaler maximum pod replica count    | `3`                                                                                         |
 | `autoscaling.targetCPUUtilizationPercentage` | Scaling target for CPU Utilization Percentage | `50`                                                                       |
 | `autoscaling.targetMemoryUtilizationPercentage` | Scaling target for Memory Utilization Percentage | `50`                                                                 |
+| `terminationGracePeriodSeconds`   | # of seconds to wait before pod killed  | `30` (Kubernetes default)                                                                   |
 | `nodeSelector`                    | Node Selector                           |                                                                                             |
 | `podDisruptionBudget`             | Pod disruption budget                   | `maxUnavailable: 1` if `replicasCount` > 1, does not create the PDB otherwise               |
 | `service.type`                    | Kubernetes LoadBalancer type            | `ClusterIP`                                                                                 |

--- a/stable/gcloud-sqlproxy/templates/deployment.yaml
+++ b/stable/gcloud-sqlproxy/templates/deployment.yaml
@@ -62,6 +62,7 @@ spec:
       {{ end -}}
       - name: cloudsql
         emptyDir: {}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
       affinity:

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -102,6 +102,10 @@ autoscaling:
 #  targetCPUUtilizationPercentage: 50
 #  targetMemoryUtilizationPercentage: 50
 
+## Number of seconds to wait before deleting the pod
+## This must be greater than or equal to the time specified with the term_timeout arg, if you have set it
+terminationGracePeriodSeconds: 30
+
 ## Node selector
 nodeSelector: {}
 
@@ -112,7 +116,7 @@ tolerations: []
 affinity: {}
 
 ## Lifecycle hooks
-## This can be helpful for gracefully terminating the proxy, when used in combination with the -term_timeout=10s extra arg
+## These can be helpful for custom graceful termination logic
 ## NOTE: Your Docker image must have a shell for the preStop command to work, the default Docker image does not have one
 lifecycleHooks: {}
 #   preStop:
@@ -124,4 +128,6 @@ podDisruptionBudget: |
   maxUnavailable: 1
 
 ## Additional container arguments
+## Uncomment the term_timeout line for the proxy to wait your chosen time before terminating connections
 extraArgs: {}
+#  term_timeout: 30s


### PR DESCRIPTION
**What this PR does / why we need it**:

One setting I found that was missing from the Chart after adjusting the `term_timeout` arg and some other values was that if I set a value longer than 30 seconds, the pod would be deleted at 30 seconds. This is because `terminationGracePeriodSeconds` is set to 30 seconds by default in Kubernetes, so any `preStop` or other process running beyond that time would be forcefully stopped.

To address this, I'm allowing that `terminationGracePeriodSeconds` value to be overridden.

**Special notes for your reviewer**:

Now that `terminationGracePeriodSeconds` is able to be configured, I edited some of my other comments to place less emphasis on the lifecycle hooks, as they aren't needed if `terminationGracePeriodSeconds` and `term_timeout` are both set. This should be helpful as it means graceful termination is possible without needing to build a custom Docker image.

#### Checklist

- [x] Chart Version bumped
- [x] Changes are documented in the README.md
