### PR TITLE
Add service account with Workload Identity support

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
-version: 0.19.2
+version: 0.19.3

--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -17,4 +17,4 @@ maintainers:
 name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
-version: 0.19.4
+version: 0.19.5

--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -17,4 +17,4 @@ maintainers:
 name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
-version: 0.19.3
+version: 0.19.4

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -67,7 +67,7 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 | `existingSecret`                  | Name of an existing secret to be used for the cloud-sql credentials | `""`                                                            |
 | `existingSecretKey`               | The key to use in the provided existing secret   | `""`                                                                               |
 | `usingGCPController`              | enable the use of the GCP Service Account Controller     | `""`                                                                       |
-| `gcpServiceAccountName`           | specify a service account name to use with GCP Controller | `""`                                                                                        |
+| `serviceAccountName`              | specify a service account name to use with GCP Controller | `""`                                                                                        |
 | `cloudsql.instances`              | List of PostgreSQL/MySQL instances      | [{instance: `instance`, project: `project`, region: `region`, port: 5432}] must be provided |
 | `resources`                       | CPU/Memory resource requests/limits     | Memory: `100/150Mi`, CPU: `100/150m`                                                        |
 | `lifecycleHooks`                  | Container lifecycle hooks               | `{}`                                                                                        |

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -85,6 +85,8 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 | `service.type`                    | Kubernetes LoadBalancer type            | `ClusterIP`                                                                                 |
 | `service.internalLB`              | Create service with `cloud.google.com/load-balancer-type: "Internal"` | Default `false`, when set to `true` you have to set also `service.type=LoadBalancer` |
 | `rbac.create`                     | Create RBAC configuration w/ SA         | `false`                                                                                     |
+| `iamServiceAccount.create`        | Create a service account to use workload identity | `false`                                                                                     |
+| `iamServiceAccount.annottions`    | Annotations for the service account to use workload identity | `""` |
 | `networkPolicy.enabled`           | Enable NetworkPolicy                    | `false`                                                                                     |
 | `networkPolicy.ingress.from`      | List of sources which should be able to access the pods selected for this rule. If empty, allows all sources. | `[]`                  |
 | `extraArgs`                       | Additional container arguments          | `{}`                                                                                        |

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -86,7 +86,7 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 | `service.internalLB`              | Create service with `cloud.google.com/load-balancer-type: "Internal"` | Default `false`, when set to `true` you have to set also `service.type=LoadBalancer` |
 | `rbac.create`                     | Create RBAC configuration w/ SA         | `false`                                                                                     |
 | `serviceAccount.create`           | Create a service account | `false` |
-| `serviceAccount.annotations`      | Annotations for the service account | `""` |
+| `serviceAccount.annotations`      | Annotations for the service account | `{}` |
 | `networkPolicy.enabled`           | Enable NetworkPolicy                    | `false`                                                                                     |
 | `networkPolicy.ingress.from`      | List of sources which should be able to access the pods selected for this rule. If empty, allows all sources. | `[]`                  |
 | `extraArgs`                       | Additional container arguments          | `{}`                                                                                        |

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -86,7 +86,8 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 | `service.internalLB`              | Create service with `cloud.google.com/load-balancer-type: "Internal"` | Default `false`, when set to `true` you have to set also `service.type=LoadBalancer` |
 | `rbac.create`                     | Create RBAC configuration w/ SA         | `false`                                                                                     |
 | `serviceAccount.create`           | Create a service account | `false` |
-| `serviceAccount.annotations`      | Annotations for the service account | `{}` |
+| `serviceAccount.annotations` | Annotations for the service account | `{}` |
+| `serviceAccount.name` |  Service account name | Generated using the fullname template |
 | `networkPolicy.enabled`           | Enable NetworkPolicy                    | `false`                                                                                     |
 | `networkPolicy.ingress.from`      | List of sources which should be able to access the pods selected for this rule. If empty, allows all sources. | `[]`                  |
 | `extraArgs`                       | Additional container arguments          | `{}`                                                                                        |

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -69,6 +69,7 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 | `usingGCPController`              | enable the use of the GCP Service Account Controller     | `""`                                                                       |
 | `serviceAccountName`              | specify a service account name to use   | `""`                                                                                        |
 | `cloudsql.instances`              | List of PostgreSQL/MySQL instances      | [{instance: `instance`, project: `project`, region: `region`, port: 5432}] must be provided |
+| `cloudsql.private`                | Flag to enable private ip connection    | false |
 | `resources`                       | CPU/Memory resource requests/limits     | Memory: `100/150Mi`, CPU: `100/150m`                                                        |
 | `lifecycleHooks`                  | Container lifecycle hooks               | `{}`                                                                                        |
 | `autoscaling.enabled`             | Enable CPU/Memory horizontal pod autoscaler | `false`                                                                                 |

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -85,8 +85,8 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 | `service.type`                    | Kubernetes LoadBalancer type            | `ClusterIP`                                                                                 |
 | `service.internalLB`              | Create service with `cloud.google.com/load-balancer-type: "Internal"` | Default `false`, when set to `true` you have to set also `service.type=LoadBalancer` |
 | `rbac.create`                     | Create RBAC configuration w/ SA         | `false`                                                                                     |
-| `iamServiceAccount.create`        | Create a service account to use workload identity | `false`                                                                                     |
-| `iamServiceAccount.annottions`    | Annotations for the service account to use workload identity | `""` |
+| `serviceAccount.create`           | Create a service account | `false` |
+| `serviceAccount.annotations`      | Annotations for the service account | `""` |
 | `networkPolicy.enabled`           | Enable NetworkPolicy                    | `false`                                                                                     |
 | `networkPolicy.ingress.from`      | List of sources which should be able to access the pods selected for this rule. If empty, allows all sources. | `[]`                  |
 | `extraArgs`                       | Additional container arguments          | `{}`                                                                                        |

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -67,9 +67,8 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 | `existingSecret`                  | Name of an existing secret to be used for the cloud-sql credentials | `""`                                                            |
 | `existingSecretKey`               | The key to use in the provided existing secret   | `""`                                                                               |
 | `usingGCPController`              | enable the use of the GCP Service Account Controller     | `""`                                                                       |
-| `serviceAccountName`              | specify a service account name to use   | `""`                                                                                        |
+| `gcpServiceAccountName`           | specify a service account name to use with GCP Controller | `""`                                                                                        |
 | `cloudsql.instances`              | List of PostgreSQL/MySQL instances      | [{instance: `instance`, project: `project`, region: `region`, port: 5432}] must be provided |
-| `cloudsql.private`                | Flag to enable private ip connection    | false |
 | `resources`                       | CPU/Memory resource requests/limits     | Memory: `100/150Mi`, CPU: `100/150m`                                                        |
 | `lifecycleHooks`                  | Container lifecycle hooks               | `{}`                                                                                        |
 | `autoscaling.enabled`             | Enable CPU/Memory horizontal pod autoscaler | `false`                                                                                 |

--- a/stable/gcloud-sqlproxy/templates/_helpers.tpl
+++ b/stable/gcloud-sqlproxy/templates/_helpers.tpl
@@ -54,7 +54,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/*
 Generate gcp service account name
 */}}
-{{- define "gcloud-sqlproxy.serviceAccountName" -}}
+{{- define "gcloud-sqlproxy.gcpServiceAccountName" -}}
 {{ default (include "gcloud-sqlproxy.fullname" .) .Values.serviceAccountName }}
 {{- end -}}
 
@@ -77,4 +77,15 @@ Check if any type of credentials are defined
 */}}
 {{- define "gcloud-sqlproxy.hasCredentials" -}}
 {{ or .Values.serviceAccountKey ( or .Values.existingSecret .Values.usingGCPController ) -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "gcloud-sqlproxy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "gcloud-sqlproxy.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
 {{- end -}}

--- a/stable/gcloud-sqlproxy/templates/deployment.yaml
+++ b/stable/gcloud-sqlproxy/templates/deployment.yaml
@@ -40,6 +40,9 @@ spec:
         {{ if $hasCredentials -}}
         - -credential_file=/secrets/cloudsql/{{ include "gcloud-sqlproxy.secretKey" . }}
         {{ end -}}
+        {{ if .Values.cloudsql.private -}}
+        - -ip_address_types=PRIVATE
+        {{ end -}}
         {{- range $key, $value := .Values.extraArgs }}
         - --{{ $key }}={{ $value }}
         {{- end }}

--- a/stable/gcloud-sqlproxy/templates/deployment.yaml
+++ b/stable/gcloud-sqlproxy/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     spec:
       {{- if .Values.serviceAccount.create }}
-      serviceAccountName: {{ include "gcloud-sqlproxy.serviceAccountName" . }}
+      serviceAccountName: {{ template "gcloud-sqlproxy.serviceAccountName" . }}
       {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"

--- a/stable/gcloud-sqlproxy/templates/deployment.yaml
+++ b/stable/gcloud-sqlproxy/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     spec:
       {{- if .Values.rbac.create }}
-      serviceAccountName: {{ include "gcloud-sqlproxy.fullname" . }}
+      serviceAccountName: {{ include "gcloud-sqlproxy.serviceAccountName" . }}
       {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
@@ -38,9 +38,6 @@ spec:
                      {{- end }}
         {{ if $hasCredentials -}}
         - -credential_file=/secrets/cloudsql/{{ include "gcloud-sqlproxy.secretKey" . }}
-        {{ end -}}
-        {{ if .Values.cloudsql.private -}}
-        - -ip_address_types=PRIVATE
         {{ end -}}
         {{- range $key, $value := .Values.extraArgs }}
         - --{{ $key }}={{ $value }}

--- a/stable/gcloud-sqlproxy/templates/deployment.yaml
+++ b/stable/gcloud-sqlproxy/templates/deployment.yaml
@@ -20,9 +20,7 @@ spec:
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     spec:
-      {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ template "gcloud-sqlproxy.serviceAccountName" . }}
-      {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}

--- a/stable/gcloud-sqlproxy/templates/deployment.yaml
+++ b/stable/gcloud-sqlproxy/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     spec:
-      {{- if .Values.rbac.create }}
+      {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "gcloud-sqlproxy.serviceAccountName" . }}
       {{- end }}
       {{- if .Values.priorityClassName }}

--- a/stable/gcloud-sqlproxy/templates/gcpserviceaccount.yaml
+++ b/stable/gcloud-sqlproxy/templates/gcpserviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "gcloud-sqlproxy.labels" . | nindent 4 }}
   name: {{ include "gcloud-sqlproxy.fullname" . }}
 spec:
-  serviceAccountIdentifier: {{ include "gcloud-sqlproxy.serviceAccountName" . }}
+  serviceAccountIdentifier: {{ include "gcloud-sqlproxy.gcpServiceAccountName" . }}
   serviceAccountDescription: Service account for accessing a managed sql instance
   secretName: {{ include "gcloud-sqlproxy.secretName" . }}
   bindings:

--- a/stable/gcloud-sqlproxy/templates/rolebinding.yaml
+++ b/stable/gcloud-sqlproxy/templates/rolebinding.yaml
@@ -12,6 +12,6 @@ roleRef:
   name: {{ include "gcloud-sqlproxy.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "gcloud-sqlproxy.fullname" . }}
+    name: {{ include "gcloud-sqlproxy.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/stable/gcloud-sqlproxy/templates/rolebinding.yaml
+++ b/stable/gcloud-sqlproxy/templates/rolebinding.yaml
@@ -12,6 +12,6 @@ roleRef:
   name: {{ include "gcloud-sqlproxy.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "gcloud-sqlproxy.serviceAccountName" . }}
+    name: {{ template "gcloud-sqlproxy.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/stable/gcloud-sqlproxy/templates/secrets.yaml
+++ b/stable/gcloud-sqlproxy/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccountKey -}}
 {{- if not .Values.existingSecret -}}
 {{- if not .Values.usingGCPController -}}
 apiVersion: v1
@@ -13,5 +14,6 @@ type: Opaque
 data:
   credentials.json: |-
     {{ .Values.serviceAccountKey }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/stable/gcloud-sqlproxy/templates/serviceaccount.yaml
+++ b/stable/gcloud-sqlproxy/templates/serviceaccount.yaml
@@ -9,5 +9,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
 {{- end }}
-  name: {{ include "gcloud-sqlproxy.serviceAccountName" . }}
+  name: {{ template "gcloud-sqlproxy.serviceAccountName" . }}
 {{- end }}

--- a/stable/gcloud-sqlproxy/templates/serviceaccount.yaml
+++ b/stable/gcloud-sqlproxy/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if or .Values.rbac.create .Values.iamServiceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -8,5 +8,11 @@ metadata:
     helm.sh/chart: {{ include "gcloud-sqlproxy.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if and .Values.iamServiceAccount.create (not .Values.rbac.create) }}
+{{- with .Values.iamServiceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}
   name: {{ include "gcloud-sqlproxy.fullname" . }}
 {{- end }}

--- a/stable/gcloud-sqlproxy/templates/serviceaccount.yaml
+++ b/stable/gcloud-sqlproxy/templates/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "gcloud-sqlproxy.labels" . | nindent 4 }}
 {{- with .Values.serviceAccount.annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
+    {{- toYaml . | nindent 4 }}
 {{- end }}
   name: {{ include "gcloud-sqlproxy.fullname" . }}
 {{- end }}

--- a/stable/gcloud-sqlproxy/templates/serviceaccount.yaml
+++ b/stable/gcloud-sqlproxy/templates/serviceaccount.yaml
@@ -9,5 +9,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
 {{- end }}
-  name: {{ include "gcloud-sqlproxy.fullname" . }}
+  name: {{ include "gcloud-sqlproxy.serviceAccountName" . }}
 {{- end }}

--- a/stable/gcloud-sqlproxy/templates/serviceaccount.yaml
+++ b/stable/gcloud-sqlproxy/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.rbac.create .Values.iamServiceAccount.create }}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -8,11 +8,9 @@ metadata:
     helm.sh/chart: {{ include "gcloud-sqlproxy.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- if and .Values.iamServiceAccount.create (not .Values.rbac.create) }}
-{{- with .Values.iamServiceAccount.annotations }}
+{{- with .Values.serviceAccount.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
-{{- end }}
 {{- end }}
   name: {{ include "gcloud-sqlproxy.fullname" . }}
 {{- end }}

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -59,11 +59,12 @@ cloudsql:
 rbac:
   create: false
 
-## service account with annotations to use iam workload identity
-## https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
-## this option with rbac should be mutually exclusive
-iamServiceAccount:
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
   create: false
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
   annotations: ""
 
 ## Specifies service type and option to enable internal LoadBalancer

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -62,10 +62,10 @@ rbac:
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: false
+  annotations: {}
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
-  annotations: ""
 
 ## Specifies service type and option to enable internal LoadBalancer
 ## If service.internalLB is true, service.type should be: LoadBalancer

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -42,7 +42,7 @@ cloudsql:
   ## Use different ports for different instances.
   instances:
     # GCP instance name.
-  - instance: "instance"
+  - instance: "instance1"
     # Optional abbreviation used to override the truncated instance name if the
     # 15 character instance name prefix is not unique for use as a port
     # identifier.
@@ -53,9 +53,18 @@ cloudsql:
     region: "region"
     # Port number for the proxy to expose for this instance.
     port: 5432
+    # Use private network connection
+  private: false
 
 rbac:
   create: false
+
+## service account with annotations to use iam workload identity
+## https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
+## this option with rbac should be mutually exclusive
+iamServiceAccount:
+  create: false
+  annotations: ""
 
 ## Specifies service type and option to enable internal LoadBalancer
 ## If service.internalLB is true, service.type should be: LoadBalancer

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -42,7 +42,7 @@ cloudsql:
   ## Use different ports for different instances.
   instances:
     # GCP instance name.
-  - instance: "instance1"
+  - instance: "instance"
     # Optional abbreviation used to override the truncated instance name if the
     # 15 character instance name prefix is not unique for use as a port
     # identifier.

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -53,15 +53,13 @@ cloudsql:
     region: "region"
     # Port number for the proxy to expose for this instance.
     port: 5432
-    # Use private network connection
-  private: false
 
 rbac:
   create: false
 
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
-  create: false
+  create: true
   annotations: {}
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds support to use a service account with only annotations to use Workload Identity https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity without the need of having a serviceAccountKey to authorize the cloud sql proxy.

Also adds support to use -ip_address_types=PRIVATE as it cannot be passed via extraArgs.

**Special notes for your reviewer**:
We are migrating sqlproxy from running as sidecar to running as an independent service and want to keep the use of workload identity. In our current setup, we only need to create an service account with 
```
annotations:
    iam.gke.io/gcp-service-account: account-name@project-name.iam.gserviceaccount.com
```
without the need to specify serviceAccountKey.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Changes are documented in the README.md
