### PR TITLE
[stable/gcloud-sqlproxy] Do not set static replica count if hpa is enabled

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -17,4 +17,4 @@ maintainers:
 name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
-version: 0.19.3
+version: 0.19.4

--- a/stable/gcloud-sqlproxy/templates/deployment.yaml
+++ b/stable/gcloud-sqlproxy/templates/deployment.yaml
@@ -7,7 +7,9 @@ metadata:
   labels:
     {{- include "gcloud-sqlproxy.labels" . | nindent 4 }}
 spec:
+{{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicasCount }}
+{{- end }}
   selector:
     matchLabels:
       {{- include "gcloud-sqlproxy.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This is needed for helm3 and beyond as per https://github.com/helm/charts/issues/19008

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Changes are documented in the README.md
