### PR TITLE
Provisioner name support

### DIFF
--- a/stable/hostpath-provisioner/Chart.yaml
+++ b/stable/hostpath-provisioner/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: "v0.2.2"
-version: 0.2.6
+appVersion: "v0.2.3"
+version: 0.2.7
 name: hostpath-provisioner
 description: hostpath-provisioner is an automatic provisioner creating Persistent Volumes from the hostpath.
 home: https://github.com/rimusz/charts/tree/master/stable/hostpath-provisioner

--- a/stable/hostpath-provisioner/README.md
+++ b/stable/hostpath-provisioner/README.md
@@ -65,6 +65,7 @@ The following table lists the configurable parameters of the `hostpath-provision
 | `storageClass.create`          | Enable creation of a StorageClass to consume this hostpath-provisioner instance   | `true`                                |
 | `storageClass.defaultClass`    | Enable as default storage class                                                   | `true`                                |
 | `storageClass.name`            | The name to assign the created StorageClass                                       | `hostpath`                            |
+| `provisionerName`              | The name to assign the created Provisioner                                        | `hostpath`                            |
 | `rbac.create`                  | Enable RABC                                                                       | `true`                                |
 | `rbac.serviceAccountName`      | Service account name                                                              | `default`                             |
 | `resources`                    | Resource limits for hostpath-provisioner pod                                      | `{}`                                  |

--- a/stable/hostpath-provisioner/templates/deployment.yaml
+++ b/stable/hostpath-provisioner/templates/deployment.yaml
@@ -33,6 +33,8 @@ spec:
                   fieldPath: spec.nodeName
             - name: NODE_HOST_PATH
               value: "{{ .Values.NodeHostPath }}"
+            - name: HOSTPATH_PROVISIONER_NAME
+              value: "{{.Values.provisionerName }}"
           volumeMounts:
             - name: pv-volume
               mountPath: /mnt/hostpath


### PR DESCRIPTION
Adds support for specifying a provisioner name into the chart, this is dependent on https://github.com/rimusz/hostpath-provisioner/pull/4 