### PR TITLE
Provisioner name support

### DIFF
--- a/stable/hostpath-provisioner/Chart.yaml
+++ b/stable/hostpath-provisioner/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "v0.2.3"
-version: 0.2.7
+version: 0.2.8
 name: hostpath-provisioner
 description: hostpath-provisioner is an automatic provisioner creating Persistent Volumes from the hostpath.
 home: https://github.com/rimusz/charts/tree/master/stable/hostpath-provisioner

--- a/stable/hostpath-provisioner/templates/storageclass.yaml
+++ b/stable/hostpath-provisioner/templates/storageclass.yaml
@@ -11,4 +11,4 @@ metadata:
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
 {{- end }}
-provisioner: hostpath
+provisioner: {{ .Values.provisionerName }}

--- a/stable/hostpath-provisioner/values.yaml
+++ b/stable/hostpath-provisioner/values.yaml
@@ -21,6 +21,9 @@ storageClass:
   ## Set a StorageClass name
   name: hostpath
 
+## Set the provisioner name
+provisionerName: hostpath
+
 ## Set the local HostPath to be used on the node
 NodeHostPath: /mnt/hostpath
 


### PR DESCRIPTION


**What this PR does / why we need it**:  This adds correctly referencing the provisioner name in the storage class template so pvc requests are correctly sent to the corresponding provisioner pod and created at the intended host path on the system. Updating this template was missed in my first PR for supporting specifying provisioner name.

#### Checklist
- [x] Chart Version bumped

