### PR TITLE
Add liveness and readiness probe for sqlproxy

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -17,4 +17,4 @@ maintainers:
 name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
-version: 0.19.6
+version: 0.19.7

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -90,6 +90,20 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 | `networkPolicy.enabled`           | Enable NetworkPolicy                    | `false`                                                                                     |
 | `networkPolicy.ingress.from`      | List of sources which should be able to access the pods selected for this rule. If empty, allows all sources. | `[]`                  |
 | `extraArgs`                       | Additional container arguments          | `{}`                                                                                        |
+| `livenessProbe.enabled`           | Would you like a livenessProbe to be enabled  | `false`                                                                               |
+| `livenessProbe.port`              | The port which will be checked by the probe   | 5432                                                                                  |
+| `livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated    | 30                                                                                    |
+| `livenessProbe.periodSeconds`     | How often to perform the probe                | 10                                                                                    |
+| `livenessProbe.timeoutSeconds`    | When the probe times out                      | 5                                                                                     |
+| `livenessProbe.failureThreshold`  | Minimum consecutive failures for the probe to be considered failed after having succeeded.  | 6                                       |
+| `livenessProbe.successThreshold`  | Minimum consecutive successes for the probe to be considered successful after having failed | 1                                       |
+| `readinessProbe.enabled`          | would you like a readinessProbe to be enabled | `false`                                                                               |
+| `readinessProbe.port`              | The port which will be checked by the probe  | 5432                                                                                  |
+| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated  | 5                                                                                     |
+| `readinessProbe.periodSeconds`    | How often to perform the probe                | 10                                                                                    |
+| `readinessProbe.timeoutSeconds`   | When the probe times out                      | 5                                                                                     |
+| `readinessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded.  | 6                                       |
+| `readinessProbe.successThreshold` | Minimum consecutive successes for the probe to be considered successful after having failed | 1                                       |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/gcloud-sqlproxy/templates/deployment.yaml
+++ b/stable/gcloud-sqlproxy/templates/deployment.yaml
@@ -51,6 +51,26 @@ spec:
         - name: {{ .instanceShortName | default (.instance | trunc 15) }}
           containerPort: {{ .port }}
         {{- end }}
+        {{- if .Values.livenessProbe.enabled }}
+        livenessProbe:
+          tcpSocket:
+            port: {{ .Values.livenessProbe.port }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
+        readinessProbe:
+          tcpSocket:
+            port: {{ .Values.readinessProbe.port }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+        {{- end }}
         volumeMounts:
         {{ if $hasCredentials -}}
         - name: cloudsql-oauth-credentials

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -99,6 +99,24 @@ resources: {}
 #    memory: 256Mi
 #    cpu: 256m
 
+livenessProbe:
+  enabled: false
+  port: 5432
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
+readinessProbe:
+  enabled: false
+  port: 5432
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
 ## Configure a HorizontalPodAutoscaler for pod autoscaling.
 ## Requires that resources requests are set above.
 autoscaling:


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds a `tcpSocket`-based liveness and readiness probes for `gcloud-sqlproxy`.

By default, it is disabled to make this change non-intrusive. There is no attempt to use one of the instance ports, the user is expected/free to define the port manually.

The values are taken from the stable [postgresql](https://github.com/helm/charts/blob/master/stable/postgresql/values.yaml) chart.

TCP checks are not ideal, I would prefer something like `pg_isready`, but for a proxy which supports not only postgresql, it seems like a decent choice. It is also [recommended](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/119) by the maintainers.

**Which issue this PR fixes**:

None

**Special notes for your reviewer**:

I have run-tested it both enabled and disabled on a 1.15 cluster with helm 3.0.2

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Changes are documented in the README.md
