### PR TITLE
Allow custom service loadBalancerIP

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -17,4 +17,4 @@ maintainers:
 name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
-version: 0.19.7
+version: 0.19.8

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -83,6 +83,7 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 | `podDisruptionBudget`             | Pod disruption budget                   | `maxUnavailable: 1` if `replicasCount` > 1, does not create the PDB otherwise               |
 | `service.type`                    | Kubernetes LoadBalancer type            | `ClusterIP`                                                                                 |
 | `service.internalLB`              | Create service with `cloud.google.com/load-balancer-type: "Internal"` | Default `false`, when set to `true` you have to set also `service.type=LoadBalancer` |
+| `service.loadBalancerIP`          | Set custom Load Balancer IP             | `""`                                                                                                    |
 | `rbac.create`                     | Create RBAC configuration w/ SA         | `false`                                                                                     |
 | `serviceAccount.create` | Create a service account | `true` |
 | `serviceAccount.annotations` | Annotations for the service account | `{}` |

--- a/stable/gcloud-sqlproxy/templates/svc.yaml
+++ b/stable/gcloud-sqlproxy/templates/svc.yaml
@@ -10,6 +10,9 @@ metadata:
     {{- include "gcloud-sqlproxy.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   ports:
   {{- range .Values.cloudsql.instances }}
   - name: {{ .instance }}

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -70,6 +70,10 @@ serviceAccount:
 service:
   type: ClusterIP
   internalLB: false
+  # Configures custom LoadBalancer IP. Compatibility depends on the cloud provider.
+  # For instance, GCP Internal LoadBalancer will take it into account.
+  # If left blank or if not supported by your cloud provider, it will be ignored.
+  loadBalancerIP: ""
 
 networkPolicy:
   ## Specifies whether a NetworkPolicy should be created


### PR DESCRIPTION
<!--
Thank you for contributing to rimusz/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

On some cloud providers, the `Service` `spec.loadBalancerIP` field allow to assign custom IP to the load balancer created behind the scenes, like documented [here](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer)

GCP supports the `loadBalancerIP` on Internal Load Balancers, so assuming this chart is mostly installed on GCP projects, I think `loadBalancerIP` should be added to this chart's values.

#### Checklist

- [x] Chart Version bumped
- [x] Changes are documented in the README.md
