### PR TITLE
Added Deploy as Statefulset Option

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
-version: 0.19.13
+version: 0.20.2

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -106,6 +106,7 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 | `readinessProbe.timeoutSeconds`   | When the probe times out                      | 5                                                                                     |
 | `readinessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded.  | 6                                       |
 | `readinessProbe.successThreshold` | Minimum consecutive successes for the probe to be considered successful after having failed | 1                                       |
+| `useStatefulset`                  | Deploy as a statefulset rather than a deployment                                            | false                                       |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
@@ -121,6 +122,10 @@ $ helm install --name my-release -f values.yaml rimusz/gcloud-sqlproxy
 
 ### Auto generating the gcp service account
 By enabling the flag `usingGCPController` and having a GCP Service Account Controller deployed in your cluster, it is possible to autogenerate and inject the service account used for connecting to the database. For more information see https://github.com/kiwigrid/helm-charts/tree/master/charts/gcp-serviceaccount-controller
+
+### Handling A Large Number of Instances
+
+GCP does not support more than 5 endpoints on an Internal Load Balancer. To work around this, you can deploy this as a Statefulset to get all the hostname-guarantees associated with statefulsets. You can then access the headless service, e.g.: `cloudsql-proxy-headless.cloudsql-proxy.svc.cluster.local`
 
 ## Documentation
 

--- a/stable/gcloud-sqlproxy/templates/deployment.yaml
+++ b/stable/gcloud-sqlproxy/templates/deployment.yaml
@@ -1,7 +1,11 @@
 {{- if ne (index .Values.cloudsql.instances 0).instance "instance" }}
 {{- $hasCredentials := include "gcloud-sqlproxy.hasCredentials" . -}}
 apiVersion: apps/v1
+{{- if .Values.useStatefulset }}
+kind: StatefulSet
+{{- else }}
 kind: Deployment
+{{- end }}
 metadata:
   name: {{ include "gcloud-sqlproxy.fullname" . }}
   labels:
@@ -13,8 +17,13 @@ spec:
   selector:
     matchLabels:
       {{- include "gcloud-sqlproxy.selectorLabels" . | nindent 6 }}
+  {{- if not .Values.useStatefulset }}
   strategy:
 {{ toYaml .Values.deploymentStrategy | indent 4 }}
+  {{- end }}
+  {{- if .Values.useStatefulset }}
+  serviceName: {{ include "gcloud-sqlproxy.fullname" . }}-headless
+  {{- end }}
   template:
     metadata:
       labels:

--- a/stable/gcloud-sqlproxy/templates/svc-statefulset.yaml
+++ b/stable/gcloud-sqlproxy/templates/svc-statefulset.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.useStatefulset }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gcloud-sqlproxy.fullname" . }}-headless
+  labels:
+    {{- include "gcloud-sqlproxy.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  {{- range .Values.cloudsql.instances }}
+  - name: {{ .instanceShortName | default (.instance | trunc 15) }}
+    protocol: TCP
+    port: {{ .port }}
+    targetPort: {{ .instanceShortName | default (.instance | trunc 15) }}
+  {{- end }}
+  selector:
+    {{- include "gcloud-sqlproxy.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -13,6 +13,10 @@ imagePullPolicy: IfNotPresent
 ## Replicas Set count
 replicasCount: 1
 
+## Set to true to use a statefulset for the deployable.
+## You can then access the nodes using the known-hostnames of a statefulset
+useStatefulset: false
+
 ## Specify the deployment strategy for pods
 deploymentStrategy: {}
 
@@ -37,6 +41,7 @@ usingGCPController: ""
 
 ## SQL connection settings
 ##
+#
 cloudsql:
   ## PostgreSQL/MySQL instances:
   ## update with your GCP project, the region of your Cloud SQL instance

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -41,7 +41,6 @@ usingGCPController: ""
 
 ## SQL connection settings
 ##
-#
 cloudsql:
   ## PostgreSQL/MySQL instances:
   ## update with your GCP project, the region of your Cloud SQL instance


### PR DESCRIPTION

**What this PR does / why we need it**:

If one is deploying more than 5 DB proxies then an internal loadbalancer on google is not supported as they must have at most 5 ports.

To fix this, I added the option to deploy as statefulset which allows you to then access the proxy using the `headless` service's FQDN to get A records:

```
# In cluster:
dig cloudsql-proxy-headless.cloudsql-proxy.svc.cluster.local
# Returns multiple A records,  one for each replica
```


**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x ] Chart Version bumped
- [ x ] Changes are documented in the README.md
