### PR TITLE
Fixes disable StorageClass creation not effect issue

### DIFF
--- a/stable/hostpath-provisioner/Chart.yaml
+++ b/stable/hostpath-provisioner/Chart.yaml
@@ -4,7 +4,8 @@ version: 0.2.10
 name: hostpath-provisioner
 description: hostpath-provisioner is an automatic provisioner creating Persistent Volumes from the hostpath.
 home: https://github.com/rimusz/charts/tree/master/stable/hostpath-provisioner
-source: https://github.com/rimusz/hostpath-provisioner
+sources:
+- https://github.com/rimusz/hostpath-provisioner
 keywords:
 - hostpath
 - storage

--- a/stable/hostpath-provisioner/Chart.yaml
+++ b/stable/hostpath-provisioner/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "v0.2.3"
-version: 0.2.9
+version: 0.2.10
 name: hostpath-provisioner
 description: hostpath-provisioner is an automatic provisioner creating Persistent Volumes from the hostpath.
 home: https://github.com/rimusz/charts/tree/master/stable/hostpath-provisioner

--- a/stable/hostpath-provisioner/templates/storageclass.yaml
+++ b/stable/hostpath-provisioner/templates/storageclass.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.storageClass.create -}}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -13,3 +14,4 @@ metadata:
 {{- end }}
 provisioner: {{ .Values.provisionerName }}
 reclaimPolicy: {{ .Values.reclaimPolicy }}
+{{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**: 

With `storageClass: false`, helm install hostpath-provisioner still create StorageClass.
Fixes CI by the way.

**Which issue this PR fixes** *(optional)*: N/A

**Special notes for your reviewer**: N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped

