### PR TITLE
hostpath-provisioner: Add nodeSelector, affinity and tolerations

### DIFF
--- a/stable/hostpath-provisioner/Chart.yaml
+++ b/stable/hostpath-provisioner/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "v0.2.3"
-version: 0.2.10
+version: 0.2.11
 name: hostpath-provisioner
 description: hostpath-provisioner is an automatic provisioner creating Persistent Volumes from the hostpath.
 home: https://github.com/rimusz/charts/tree/master/stable/hostpath-provisioner

--- a/stable/hostpath-provisioner/README.md
+++ b/stable/hostpath-provisioner/README.md
@@ -66,10 +66,13 @@ The following table lists the configurable parameters of the `hostpath-provision
 | `storageClass.defaultClass`    | Enable as default storage class                                                   | `true`                                |
 | `storageClass.name`            | The name to assign the created StorageClass                                       | `hostpath`                            |
 | `provisionerName`              | The name to assign the created Provisioner                                        | `hostpath`                            |
-| `reclaimPolicy`                | Set the reclaimPolicy | `Delete` |
+| `reclaimPolicy`                | Set the reclaimPolicy                                                             | `Delete`                              |
 | `rbac.create`                  | Enable RABC                                                                       | `true`                                |
 | `rbac.serviceAccountName`      | Service account name                                                              | `default`                             |
 | `resources`                    | Resource limits for hostpath-provisioner pod                                      | `{}`                                  |
+| `nodeSelector`                 | Node Selector                                                                     | `{}`                                  |
+| `tolerations`                  | Tolerations for pod assignment                                                    | `[]`                                  |
+| `affinity`                     | Affinity for pod assignment                                                       | `{}`                                  |
 
 ```console
 $ helm install rimusz/hostpath-provisioner --name hostpath-provisioner \

--- a/stable/hostpath-provisioner/templates/deployment.yaml
+++ b/stable/hostpath-provisioner/templates/deployment.yaml
@@ -44,3 +44,15 @@ spec:
         - name: pv-volume
           hostPath:
             path: {{ .Values.NodeHostPath }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/stable/hostpath-provisioner/values.yaml
+++ b/stable/hostpath-provisioner/values.yaml
@@ -30,6 +30,15 @@ reclaimPolicy: Delete
 ## Set the local HostPath to be used on the node
 NodeHostPath: /mnt/hostpath
 
+## Node selector
+nodeSelector: {}
+
+## Affinity
+affinity: {}
+
+## Tolerations
+tolerations: []
+
 rbac:
   create: true
   ## Ignored if rbac.create is true


### PR DESCRIPTION
**What this PR does / why we need it**:

Add nodeSelector, affinity and tolerations. I need nodeSelector and tolerations to run on amd64 nodes (not arm64) in my multi-arch cluster.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Changes are documented in the README.md
