### PR TITLE
Trim suffix dash from port name in gcloud-sqlproxy

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
-version: 0.20.5
+version: 0.20.6

--- a/stable/gcloud-sqlproxy/templates/_helpers.tpl
+++ b/stable/gcloud-sqlproxy/templates/_helpers.tpl
@@ -89,3 +89,10 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the short instance name
+*/}}
+{{- define "gcloud-sqlproxy.instanceShortName" -}}
+{{ .instanceShortName | default (.instance | trunc 15 | trimSuffix "-") }}
+{{- end -}}

--- a/stable/gcloud-sqlproxy/templates/deployment.yaml
+++ b/stable/gcloud-sqlproxy/templates/deployment.yaml
@@ -61,7 +61,8 @@ spec:
         {{- end }}
         ports:
         {{- range .Values.cloudsql.instances }}
-        - name: {{ .instanceShortName | default (.instance | trunc 15) }}
+        {{- $instanceShortName := include "gcloud-sqlproxy.instanceShortName" . }}
+        - name: {{ $instanceShortName }}
           containerPort: {{ .port }}
         {{- end }}
         {{- if .Values.livenessProbe.enabled }}

--- a/stable/gcloud-sqlproxy/templates/svc-statefulset.yaml
+++ b/stable/gcloud-sqlproxy/templates/svc-statefulset.yaml
@@ -10,10 +10,11 @@ spec:
   clusterIP: None
   ports:
   {{- range .Values.cloudsql.instances }}
-  - name: {{ .instanceShortName | default (.instance | trunc 15) }}
+  {{- $instanceShortName := include "gcloud-sqlproxy.instanceShortName" . }}
+  - name: {{ $instanceShortName }}
     protocol: TCP
     port: {{ .port }}
-    targetPort: {{ .instanceShortName | default (.instance | trunc 15) }}
+    targetPort: {{ $instanceShortName }}
   {{- end }}
   selector:
     {{- include "gcloud-sqlproxy.selectorLabels" . | nindent 4 }}

--- a/stable/gcloud-sqlproxy/templates/svc.yaml
+++ b/stable/gcloud-sqlproxy/templates/svc.yaml
@@ -18,10 +18,11 @@ spec:
   {{- end }}
   ports:
   {{- range .Values.cloudsql.instances }}
-  - name: {{ .instanceShortName | default (.instance | trunc 15) }}
+  {{- $instanceShortName := include "gcloud-sqlproxy.instanceShortName" . }}
+  - name: {{ $instanceShortName }}
     protocol: TCP
     port: {{ .port }}
-    targetPort: {{ .instanceShortName | default (.instance | trunc 15) }}
+    targetPort: {{ $instanceShortName }}
   {{- end }}
   selector:
     {{- include "gcloud-sqlproxy.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
<!--
Thank you for contributing to rimusz/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

When your instance name has `-` as 15th character, it caused invalid name to be generated. This PR fixes it by trimming trailing `-`.

#### Checklist
- [x] Chart Version bumped

@rimusz @naseemkullah 