### PR TITLE
Cloud SQL Proxy version bump

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.16"
+appVersion: "1.24.0"
 description: Google Cloud SQL Proxy
 engine: gotpl
 home: https://cloud.google.com/sql/docs/postgres/sql-proxy
@@ -18,4 +18,4 @@ maintainers:
 name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
-version: 0.20.6
+version: 0.21.0

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -112,7 +112,7 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
-The `extraArgs` can be provided via dot notation, e.g. `--set extraArgs.log_debug_stdout=true` passes `--log_debug_stdout=false` to the SQL Proxy command.
+The `extraArgs` can be provided via dot notation, e.g. `--set extraArgs.log_debug_stdout=true` passes `--log_debug_stdout=true` to the SQL Proxy command.
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -2,7 +2,7 @@
 ## ref: https://cloud.google.com/sql/docs/mysql/sql-proxy
 ## ref: https://cloud.google.com/sql/docs/postgres/sql-proxy
 image: gcr.io/cloudsql-docker/gce-proxy
-imageTag: "1.16"
+imageTag: "1.24.0"
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
Update Cloud SQL Proxy version to 1.24.0.

Minor fixes in readme.