### PR TITLE
Remove apis that wont work in k8s 1.22

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -19,4 +19,4 @@ name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
 type: application
-version: 0.22.1
+version: 0.22.2

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -138,7 +138,7 @@ GCP does not support more than 5 endpoints on an Internal Load Balancer. To work
 
 ## Upgrading
 
-**From < 0.22.0 to >= 0.22.1**
+**From < 0.22.0 to >= 0.22.2**
 
 Please note, as of `0.22.1` image `repository`, `tag` and `pullPolicy` values use new variables, if not using the defaults, you will need to rename them.
 

--- a/stable/gcloud-sqlproxy/templates/pdb.yaml
+++ b/stable/gcloud-sqlproxy/templates/pdb.yaml
@@ -1,5 +1,9 @@
 {{- if and .Values.podDisruptionBudget (gt (.Values.replicasCount | int) 1) -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/stable/gcloud-sqlproxy/templates/role.yaml
+++ b/stable/gcloud-sqlproxy/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: {{ .Values.namespace }}

--- a/stable/gcloud-sqlproxy/templates/rolebinding.yaml
+++ b/stable/gcloud-sqlproxy/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: {{ .Values.namespace }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes deprecated api usage which is removed in 1.22. New APIs available from 1.8 on.
See also https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Changes are documented in the README.md

This is not my code. I've just seen @cdaguerre already did the changes I was going to make but did not create a pull request to this repo.