### PR TITLE
[nfs-provisioner] added default StorageClass config value

### DIFF
--- a/stable/nfs-client-provisioner/Chart.yaml
+++ b/stable/nfs-client-provisioner/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v3.1.0-k8s1.11"
-version: 0.1.5
+version: 0.1.6
 type: application
 name: nfs-client-provisioner
 description: nfs-client-provisioner is an automatic provisioner creating Persistent Volumes from the NFS

--- a/stable/nfs-client-provisioner/README.md
+++ b/stable/nfs-client-provisioner/README.md
@@ -92,6 +92,7 @@ their default values.
 | `nfs.server`                   | NFS server IP                                                                     | ``                                                    |
 | `nfs.path`                     | NFS server share path                                                             | `/vol1`                                               |
 | `storageClass.create`          | Enable creation of a StorageClass to consume this nfs-client-provisioner instance | `true`                                                |
+| `storageClass.default`         | Set this StorageClass as the default                                              | `false`                                                |
 | `storageClass.name`            | The name to assign the created StorageClass                                       | `nfs`                                                 |
 | `storageClass.reclaimPolicy`   | Set the reclaimPolicy for PV within StorageClass                                  | `Delete`                                              |
 | `rbac.create`                  | Enable RBAC                                                                       | `false`                                               |

--- a/stable/nfs-client-provisioner/README.md
+++ b/stable/nfs-client-provisioner/README.md
@@ -94,7 +94,7 @@ their default values.
 | `storageClass.create`          | Enable creation of a StorageClass to consume this nfs-client-provisioner instance | `true`                                                |
 | `storageClass.name`            | The name to assign the created StorageClass                                       | `nfs`                                                 |
 | `storageClass.reclaimPolicy`   | Set the reclaimPolicy for PV within StorageClass                                  | `Delete`                                              |
-| `rbac.create`                  | Enable RABC                                                                       | `false`                                               |
+| `rbac.create`                  | Enable RBAC                                                                       | `false`                                               |
 | `rbac.serviceAccountName`      | Service account name                                                              | `default`                                             |
 | `resources`                    | Resource limits for nfs-client-provisioner pod                                    | `{}`                                                  |
 | `nodeSelector`                 | Map of node labels for pod assignment                                             | `{}`                                                  |

--- a/stable/nfs-client-provisioner/templates/storageclass.yaml
+++ b/stable/nfs-client-provisioner/templates/storageclass.yaml
@@ -3,6 +3,10 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: {{ .Values.storageClass.name }}
+  {{- if .Values.storageClass.default }}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  {{- end }}
   labels:
     app: {{ template "nfs-client-provisioner.name" . }}
     chart: {{ template "nfs-client-provisioner.chart" . }}

--- a/stable/nfs-client-provisioner/values.yaml
+++ b/stable/nfs-client-provisioner/values.yaml
@@ -22,6 +22,9 @@ nfs:
 storageClass:
   create: true
 
+  ## Set annotation for default storage class
+  default: false
+
   ## Set a StorageClass name
   name: nfs
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Added a optional value for setting nfs-provisioner as default storage class

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)

