### PR TITLE
[gcloud-sqlproxy] README: missing quote

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -19,4 +19,4 @@ name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
 type: application
-version: 0.22.7
+version: 0.22.8

--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.24.0
+appVersion: 1.30.1
 description: Google Cloud SQL Proxy
 engine: gotpl
 home: https://cloud.google.com/sql/docs/postgres/sql-proxy

--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -19,4 +19,4 @@ name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
 type: application
-version: 0.22.6
+version: 0.22.7

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -60,7 +60,7 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 | Parameter                         | Description                             | Default                                                                                     |
 | --------------------------------- | --------------------------------------  | ---------------------------------------------------------                                   |
 | `image`                           | SQLProxy image                          | `gcr.io/cloudsql-docker/gce-proxy`                                                        |
-| `imageTag`                        | SQLProxy image tag                      | `1.16`                                                                                      |
+| `image.tag`                        | SQLProxy image tag                      | AppVersion: `1.26.0`                                                                                      |
 | `imagePullPolicy`                 | Image pull policy                       | `IfNotPresent`                                                                              |
 | `replicasCount`                   | Replicas count                          | `1`                                                                                         |
 | `deploymentStrategy`              | Deployment strategy for pods            | `{}`                                                                                        |

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -60,7 +60,7 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 | Parameter                         | Description                             | Default                                                                                     |
 | --------------------------------- | --------------------------------------  | ---------------------------------------------------------                                   |
 | `image`                           | SQLProxy image                          | `gcr.io/cloudsql-docker/gce-proxy`                                                        |
-| `image.tag`                        | SQLProxy image tag                      | AppVersion: `1.26.0`                                                                                      |
+| `image.tag`                        | SQLProxy image tag                      | AppVersion: `1.30.1`                                                                                      |
 | `imagePullPolicy`                 | Image pull policy                       | `IfNotPresent`                                                                              |
 | `replicasCount`                   | Replicas count                          | `1`                                                                                         |
 | `deploymentStrategy`              | Deployment strategy for pods            | `{}`                                                                                        |

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -116,7 +116,7 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 | `httpReadinessProbe.port`         | Overrides the default http port               | 8090                                        |
 | `httpLivenessProbe.enabled`       | Enables http liveness  probe                  | `false`                                       |
 | `httpLivenessProbe.port`          | Overrides the default http port               | 8090                                        |
-| `topologySpreadConstraints        | List of TopologySpreadConstraints             | `[]`                                        |
+| `topologySpreadConstraints`        | List of TopologySpreadConstraints             | `[]`                                        |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix the documentation A quote is missing at the end of topologySpreadConstraints

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)

