### PR TITLE
[gcloud-sqlproxy] Support adding extra env variables in deployment

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -19,4 +19,4 @@ name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
 type: application
-version: 0.22.9
+version: 0.22.10

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -43,6 +43,10 @@ Replace Postgres/MySQL host with: if access is from the same namespace with `pg-
 
 > **Tip**: Because of limitations on the length of port names, the `instance` value for each of the instances must be unique for the first 15 characters.
 
+> **Tip**: If you wish to source some `cloussql.instances[]` parameter values from ConfigMaps or Secrets, you may fetch them via `env` parameter and refer
+  to them via `$()` [interpolation syntax](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#use-configmap-defined-environment-variables-in-pod-commands),
+  e.g.: `cloudsql.instances[0].region=$(REGION)`
+
 ## Uninstalling the Chart
 
 To uninstall/delete the `my-release-name` deployment:
@@ -72,6 +76,7 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 | `serviceAccountName`              | specify a service account name to use with GCP Controller | `""`                                                                                        |
 | `cloudsql.instances`              | List of PostgreSQL/MySQL instances      | [{instance: `instance`, project: `project`, region: `region`, port: 5432}] must be provided |
 | `resources`                       | CPU/Memory resource requests/limits     | Memory: `100/150Mi`, CPU: `100/150m`                                                        |
+| `env`                             | Extra [environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for container | `{}` |
 | `lifecycleHooks`                  | Container lifecycle hooks               | `{}`                                                                                        |
 | `autoscaling.enabled`             | Enable CPU/Memory horizontal pod autoscaler | `false`                                                                                 |
 | `autoscaling.minReplicas`         | Autoscaler minimum pod replica count    | `1`                                                                                         |

--- a/stable/gcloud-sqlproxy/templates/deployment.yaml
+++ b/stable/gcloud-sqlproxy/templates/deployment.yaml
@@ -70,6 +70,10 @@ spec:
         {{- range $key, $value := .Values.extraArgs }}
         - --{{ $key }}={{ $value }}
         {{- end }}
+        {{- if .Values.env }}
+        env:
+{{ toYaml .Values.env | indent 10 }}
+        {{- end }}
         {{- if .Values.lifecycleHooks }}
         lifecycle:
 {{ toYaml .Values.lifecycleHooks | indent 10 }}

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -183,6 +183,12 @@ tolerations: []
 ## Affinity
 affinity: {}
 
+## Extra environment variables. Might be used to fetch instance data from
+## Config maps or Secrets and used via interpolation '$()' syntax in
+## cloudsql.instances[].* helm variables. See:
+## https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#use-configmap-defined-environment-variables-in-pod-commands
+env: {}
+
 ## Lifecycle hooks
 ## These can be helpful for custom graceful termination logic
 ## NOTE: Your Docker image must have a shell for the preStop command to work, the default Docker image does not have one


### PR DESCRIPTION
<!--
Thank you for contributing to rimusz/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Might be be used to fetch instance data from ConfigMaps or Secrets and used via interpolation `$()` syntax in `cloudsql.instances[].*` helm variables.

**Special notes for your reviewer**:

#### Checklist

- [x] Chart Version bumped
- [x] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)

CC: @rimusz @naseemkullah 