### PR TITLE
[gcloud-sqlproxy]) add security contexts

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -19,4 +19,4 @@ name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
 type: application
-version: 0.22.10
+version: 0.23.0

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -101,7 +101,8 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 | `networkPolicy.enabled`           | Enable NetworkPolicy                    | `false`                                                                                     |
 | `networkPolicy.ingress.from`      | List of sources which should be able to access the pods selected for this rule. If empty, allows all sources. | `[]`                  |
 | `extraArgs`                       | Additional container arguments          | `{}`                                                                                        |
-| `securityContext`                 | Configure Security Context              | `{}` |
+| `podSecurityContext`              | Configure Pod Security Context          | `{}` |
+| `containerSecurityContext`        | Configure Container Security Context    | `{}` |
 | `livenessProbe.enabled`           | Would you like a livenessProbe to be enabled  | `false`                                                                               |
 | `livenessProbe.port`              | The port which will be checked by the probe   | 5432                                                                                  |
 | `livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated    | 30                                                                                    |
@@ -151,6 +152,10 @@ GCP does not support more than 5 endpoints on an Internal Load Balancer. To work
 
 
 ## Upgrading
+
+**From <= 0.22.2 to >= 0.23.0**
+
+Please note, the `securityContext` has been renamed into `podSecurityContext`.
 
 **From < 0.22.0 to >= 0.22.2**
 

--- a/stable/gcloud-sqlproxy/templates/deployment.yaml
+++ b/stable/gcloud-sqlproxy/templates/deployment.yaml
@@ -41,8 +41,10 @@ spec:
       topologySpreadConstraints: {{ toYaml .Values.topologySpreadConstraints | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ template "gcloud-sqlproxy.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.securityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
@@ -50,6 +52,10 @@ spec:
       - name: sqlproxy
         image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
         imagePullPolicy: {{ default "" .Values.image.pullPolicy | quote }}
+        {{- with .Values.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         command:

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -166,10 +166,15 @@ podAnnotations: {}
 ## Pod labels
 podLabels: {}
 
-## Configure Security Context
-securityContext: {}
+## Configure Pod Security Context
+podSecurityContext: {}
 #   runAsUser: 1000
 #   fsGroup: 1000
+
+## Configure Container Security Context
+containerSecurityContext: {}
+#   allowPrivilegeEscalation: false
+
 
 ## Configure Pod Priority
 priorityClassName: ""


### PR DESCRIPTION
* Rename the securityContext value into podSecurityContext
* Add containerSecurityContext
* Increment minor. Introducing a breaking change, should we change the major?

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped, is mandatory for any chart chnages
- [x] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[gcloud-sqlproxy]`)

