### PR TITLE
[gcloud-sqlproxy] Update obsolete hpa api, bump app version to 1.33.4

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.31.1
+appVersion: 1.33.4
 description: Google Cloud SQL Proxy
 engine: gotpl
 home: https://cloud.google.com/sql/docs/postgres/sql-proxy
@@ -19,4 +19,4 @@ name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
 type: application
-version: 0.23.0
+version: 0.24.0

--- a/stable/gcloud-sqlproxy/templates/horizontalpodautoscaler.yaml
+++ b/stable/gcloud-sqlproxy/templates/horizontalpodautoscaler.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.autoscaling.enabled .Values.resources}}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   labels:
@@ -10,7 +10,7 @@ metadata:
   name: {{ include "gcloud-sqlproxy.fullname" . }}
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: {{ include "gcloud-sqlproxy.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}


### PR DESCRIPTION
**What this PR does / why we need it**:
updates hpa api 
autoscaling/v2beta1 -> autoscaling/v2

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v125
 autoscaling/v2 API version, available since v1.23

Maintenance support of kubernetes v.23 ended (28 Feb 2023), time to move autoscaling/v2, as it is everywhere now


**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped, is mandatory for any chart chnages
- [x] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[gcloud-sqlproxy]`)

