### PR TITLE
[gcloud-sqlproxy] fix issue 134 - hpa metrics schema

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -19,4 +19,4 @@ name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
 type: application
-version: 0.24.0
+version: 0.24.1

--- a/stable/gcloud-sqlproxy/templates/horizontalpodautoscaler.yaml
+++ b/stable/gcloud-sqlproxy/templates/horizontalpodautoscaler.yaml
@@ -20,12 +20,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**: This will fix an issue using `autoscaling/v2` in hpa.

**Which issue this PR fixes** fixes #134 

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped, is mandatory for any chart chnages
- [X] Title of the PR starts with chart name (e.g. `[gcloud-sqlproxy]`)

