### PR TITLE
[gcloud-sqlproxy] HPA kind depends on useStatefulset variable - #142

### DIFF
--- a/stable/gcloud-sqlproxy/templates/horizontalpodautoscaler.yaml
+++ b/stable/gcloud-sqlproxy/templates/horizontalpodautoscaler.yaml
@@ -11,7 +11,11 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
+  {{- if .Values.useStatefulset }}
+    kind: Statefulset
+  {{- else }}
     kind: Deployment
+  {{- end }}
     name: {{ include "gcloud-sqlproxy.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}


### PR DESCRIPTION
<!--
Thank you for contributing to rimusz/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Fixed HorizontalPodAutoscaler to set the kind depending of the value of useStatefulset . Before it was set to Deployment no matter if you are using statefulset so it didn't work.

**Which issue this PR fixes** :
fixes #142 

**Special notes for your reviewer**:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped, is mandatory for any chart chnages
- [x] Title of the PR starts with chart name (e.g. `[gcloud-sqlproxy]`)

